### PR TITLE
Add static wallet pages

### DIFF
--- a/public/wallet/index.html
+++ b/public/wallet/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Miden Wallet</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Miden Wallet – a self-custodial browser wallet for the Miden blockchain." />
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; margin: 0; padding: 48px 20px; max-width: 760px; color: #111; line-height: 1.55; }
+      h1 { margin: 0 0 12px; font-size: 32px; }
+      p { margin: 12px 0; }
+      a { color: #0052ff; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .meta { color: #444; }
+    </style>
+  </head>
+  <body>
+    <h1>Miden Wallet</h1>
+    <p class="meta">Browser extension wallet for Miden.</p>
+
+    <p>
+      Miden Wallet is a self-custodial browser wallet. Key management, signing, and transaction construction
+      happen locally in your browser. Transaction proofs can be handled by the remote prover or locally.
+    </p>
+
+    <p><a href="/wallet/privacy">Privacy Policy</a></p>
+  </body>
+</html>

--- a/public/wallet/privacy/index.html
+++ b/public/wallet/privacy/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Miden Wallet – Privacy Policy</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; margin: 0; padding: 48px 20px; max-width: 760px; color: #111; line-height: 1.55; }
+      h1 { margin: 0 0 12px; font-size: 32px; }
+      h2 { margin: 28px 0 8px; font-size: 18px; }
+      p { margin: 10px 0; }
+    </style>
+  </head>
+  <body>
+    <h1>Privacy Policy – Miden Wallet</h1>
+
+    <p>
+      The Miden Wallet browser extension does not collect, transmit, sell, or share personal data.
+    </p>
+
+    <h2>Local processing</h2>
+    <p>
+      Cryptographic operations (including key management and signing) and transaction construction are performed
+      locally in the user’s browser. Proving by default happens in the remote prover.
+    </p>
+
+    <h2>No tracking</h2>
+    <p>
+      The extension does not track browsing activity, user behavior, or website content outside of what is required
+      to provide wallet functionality.
+    </p>
+
+    <h2>No third-party sharing</h2>
+    <p>No user data is shared with third parties.</p>
+  </body>
+</html>

--- a/public/wallet/privacy/index.html
+++ b/public/wallet/privacy/index.html
@@ -32,5 +32,9 @@
 
     <h2>No third-party sharing</h2>
     <p>No user data is shared with third parties.</p>
+
+    <p>
+      <a href="/wallet/">Back to Miden Wallet</a>
+    </p>
   </body>
 </html>


### PR DESCRIPTION
This PR adds two new pages for the wallet. We need them to be able to publish the wallet to the Chrome store. This is a temporary solution. In the future, we can add non-static pages to the homepage.